### PR TITLE
Subscan handling mainly for OTF mode.

### DIFF
--- a/evla_mcast/angles.py
+++ b/evla_mcast/angles.py
@@ -51,9 +51,9 @@ converting angles between various units, normalizing angles into a
 given range, finding separation and bearing bewteen two points and
 others. Normalization of angles can be performed in two different
 ways. One method normalizes angles in the manner that longitudinal
-angles are normalized i.e., [0, 360.0) or [0, 2π) or [0, 24.0). The
+angles are normalized i.e., [0, 360.0) or [0, 2pi) or [0, 24.0). The
 other method normalizes angles in the manner that latitudinal angles
-are normalized i.e., [-90, 90] or [-π/2, π/2].
+are normalized i.e., [-90, 90] or [-pi/2, pi2].
 
 See docstrings of classes and functions for documentation and examples.
 
@@ -250,7 +250,7 @@ def h2h(h):
 
 
 def r2r(r):
-    """Normalize angle in radians to [0, 2π)."""
+    """Normalize angle in radians to [0, 2pi)."""
     return normalize(r, 0, 2 * math.pi)
 
 
@@ -729,7 +729,7 @@ def phmsdms(hmsdms):
 def sep(a1, b1, a2, b2):
     """Angular spearation between two points on a unit sphere.
 
-    This will be an angle between [0, π] radians.
+    This will be an angle between [0, pi] radians.
 
     Parameters
     ----------
@@ -745,7 +745,7 @@ def sep(a1, b1, a2, b2):
     -----
     The great cicle angular separation of the second point from the
     first is returned as an angle in radians. the return value is
-    always in the range [0, π].
+    always in the range [0, pi].
 
     Results agree with those from SLALIB routine sla_dsep. See
     _test_with_slalib().
@@ -809,8 +809,8 @@ def bear(a1, b1, a2, b2):
     Position angle of the second point with respect to the first
     is returned in radians. Position angle is calculated clockwise
     and counter-clockwise from the direction towards the North
-    pole. It is between [0 and π] if the second point is in the
-    eastern hemisphere w.r.t the first, and between (0, -π) if
+    pole. It is between [0 and pi] if the second point is in the
+    eastern hemisphere w.r.t the first, and between (0, -pi) if
     the second point is in the western hemisphere w.r.t the first.
 
     .. warning::
@@ -1003,7 +1003,7 @@ class Angle(object):
 
     >>> a.s1 = u"\u00B0 "
     >>> print unicode(a)
-    +12° 34MM 16.593SS
+    +12 34MM 16.593SS
 
     The default unit is inferred from the input values.
 
@@ -1317,7 +1317,7 @@ class AlphaAngle(Angle):
 
     def _setnorm(self, val):
         # override method from Angle.
-        self._raw = r2r(val)  # [0, 2π) i.e., h = [0, 24).
+        self._raw = r2r(val)  # [0, 2pi) i.e., h = [0, 24).
 
     def __getounit(self):
         return self.__ounit

--- a/evla_mcast/scan_config.py
+++ b/evla_mcast/scan_config.py
@@ -173,6 +173,26 @@ class ScanConfig(object):
         return self.get_intent("ScanIntent", "None")
 
     @property
+    def otf(self):
+        return self.get_intent("OTF","0") == "1"
+
+    @property
+    def otf_rate_ra(self):
+        return float(self.get_intent("AntennaRaRate","0").strip('"'))
+
+    @property
+    def otf_rate_dec(self):
+        return float(self.get_intent("AntennaDecRate","0").strip('"'))
+
+    @property
+    def otf_duration(self):
+        return float(self.get_intent("DurationOfStripe","0").strip('"'))
+
+    @property
+    def otf_source_field(self):
+        return self.get_intent("SourceFieldSet","None").strip('"')
+
+    @property
     def nchan(self):
         return int(self.get_intent("PsrNumChan", 32))
 

--- a/evla_mcast/scan_config.py
+++ b/evla_mcast/scan_config.py
@@ -99,7 +99,7 @@ class ScanConfig(object):
     def is_complete(self):
         if ('obs' in self.requires) and not self.has_obs:
             return False
-        if ('vci' in self.requires) and not self.has_obs:
+        if ('vci' in self.requires) and not self.has_vci:
             return False
         if ('ant' in self.requires) and not self.has_ant:
             return False


### PR DESCRIPTION
Still in progress so not totally ready to merge.

Basic plan is to group subscans under a single `ScanConfig` object as discussed in #12 rather than as independent scans.  This should help handling of OTF observations for realfast.  The main changes are:
- Some new OTF-related properties in `ScanConfig`
- The first subscan in a scan creates a `ScanConfig` object as before.  Additional subscans also have `ScanConfig` instance, these are collected in a list inside the first one.  The whole group can be accessed via `ScanConfig.subscans` property.
- `Controller.handle_config` is called when the first subscan has complete info (same as before).
- When additional subscans have updated info, `Controller.handle_subscan` is called instead.

Any of this can be changed if it doesn't work as we need it to..